### PR TITLE
feat: Add 'Join Event' navigation button and invite code entry page

### DIFF
--- a/events/forms.py
+++ b/events/forms.py
@@ -5,6 +5,29 @@ from django.utils import timezone
 from .models import Event, NotificationSchedule, Participant
 
 
+class InviteCodeForm(forms.Form):
+    """Form for entering an event invite code."""
+
+    invite_code = forms.CharField(
+        max_length=8,
+        min_length=8,
+        widget=forms.TextInput(
+            attrs={
+                "class": "form-control",
+                "placeholder": "Enter 8-character invite code",
+                "style": "text-transform: uppercase;",
+            }
+        ),
+        help_text="Enter the invite code you received from the event organizer",
+    )
+
+    def clean_invite_code(self):
+        invite_code = self.cleaned_data.get("invite_code", "").upper()
+        if not Event.objects.filter(invite_code=invite_code, is_active=True).exists():
+            raise ValidationError("Invalid or inactive invite code. Please check and try again.")
+        return invite_code
+
+
 class EventForm(forms.ModelForm):
     """Form for creating/updating events."""
 

--- a/events/templates/events/invite_code_entry.html
+++ b/events/templates/events/invite_code_entry.html
@@ -1,0 +1,86 @@
+{% extends "base.html" %}
+
+{% block title %}Join an Event - Secret Santa{% endblock %}
+
+{% block content %}
+<div style="max-width: 600px; margin: 0 auto;">
+    <div style="text-align: center; margin-bottom: 40px;">
+        <h1 style="color: var(--forest-green); font-size: 36px; font-weight: 700; margin-bottom: 12px;">
+            Join a Secret Santa Event
+        </h1>
+        <p style="color: var(--soft-gray); font-size: 18px;">
+            Enter the invite code you received from your event organizer
+        </p>
+    </div>
+
+    <div style="background: white; padding: 40px; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,0.05);">
+        <form method="post">
+            {% csrf_token %}
+
+            {% if form.non_field_errors %}
+                <div class="message error" style="margin-bottom: 20px;">
+                    {{ form.non_field_errors }}
+                </div>
+            {% endif %}
+
+            <div style="margin-bottom: 24px;">
+                <label for="{{ form.invite_code.id_for_label }}" style="display: block; font-weight: 500; color: var(--charcoal); margin-bottom: 8px; font-size: 16px;">
+                    Invite Code <span style="color: var(--deep-red);">*</span>
+                </label>
+                {{ form.invite_code }}
+                {% if form.invite_code.errors %}
+                    <div style="color: var(--deep-red); font-size: 14px; margin-top: 8px;">
+                        {{ form.invite_code.errors }}
+                    </div>
+                {% endif %}
+                {% if form.invite_code.help_text %}
+                    <p style="color: var(--soft-gray); font-size: 13px; margin-top: 8px;">
+                        {{ form.invite_code.help_text }}
+                    </p>
+                {% endif %}
+            </div>
+
+            <div>
+                <button type="submit" class="btn" style="width: 100%; padding: 16px; font-size: 16px;">
+                    Continue to Event
+                </button>
+            </div>
+        </form>
+
+        <div style="margin-top: 32px; padding-top: 32px; border-top: 1px solid #eee; text-align: center;">
+            <p style="color: var(--soft-gray); font-size: 14px; margin-bottom: 12px;">
+                Don't have an invite code?
+            </p>
+            <p style="color: var(--soft-gray); font-size: 14px;">
+                Ask your event organizer to share the 8-character code with you, or check your email invitation.
+            </p>
+        </div>
+    </div>
+</div>
+
+<style>
+    input[type="text"] {
+        width: 100%;
+        padding: 16px;
+        border: 2px solid #ddd;
+        border-radius: 6px;
+        font-size: 18px;
+        font-family: 'Courier New', monospace;
+        font-weight: 600;
+        letter-spacing: 2px;
+        text-align: center;
+        transition: border-color 0.2s;
+    }
+
+    input[type="text"]:focus {
+        outline: none;
+        border-color: var(--forest-green);
+    }
+
+    input[type="text"]::placeholder {
+        letter-spacing: normal;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+        font-weight: 400;
+    }
+</style>
+{% endblock %}

--- a/events/urls.py
+++ b/events/urls.py
@@ -58,6 +58,8 @@ urlpatterns = [
 
 # Public URLs (no auth required)
 public_urlpatterns = [
+    # Invite code entry landing page
+    path("join/", views.InviteCodeEntryView.as_view(), name="invite-code-entry"),
     # Join event via invite code
     path("join/<str:invite_code>/", views.ParticipantJoinView.as_view(), name="join-event"),
     # Participant management

--- a/events/views.py
+++ b/events/views.py
@@ -8,7 +8,7 @@ from django.urls import reverse, reverse_lazy
 from django.utils import timezone
 from django.views.generic import CreateView, DeleteView, DetailView, ListView, UpdateView, View
 
-from .forms import EventForm, NotificationScheduleForm, ParticipantJoinForm, ParticipantUpdateForm
+from .forms import EventForm, InviteCodeForm, NotificationScheduleForm, ParticipantJoinForm, ParticipantUpdateForm
 from .models import Assignment, Event, NotificationSchedule, Participant
 
 
@@ -126,6 +126,25 @@ class EventDeleteView(LoginRequiredMixin, DeleteView):
 
 
 # Participant Views
+
+
+class InviteCodeEntryView(View):
+    """Landing page for entering invite code to join an event."""
+
+    def get(self, request):
+        from django.shortcuts import render
+
+        form = InviteCodeForm()
+        return render(request, "events/invite_code_entry.html", {"form": form})
+
+    def post(self, request):
+        from django.shortcuts import render
+
+        form = InviteCodeForm(request.POST)
+        if form.is_valid():
+            invite_code = form.cleaned_data["invite_code"]
+            return redirect("events:join-event", invite_code=invite_code)
+        return render(request, "events/invite_code_entry.html", {"form": form})
 
 
 class ParticipantJoinView(CreateView):

--- a/templates/base.html
+++ b/templates/base.html
@@ -165,8 +165,10 @@
                     {% if user.is_authenticated %}
                         <li><a href="{% url 'events:event-list' %}">My Events</a></li>
                         <li><a href="{% url 'events:event-create' %}">Create Event</a></li>
+                        <li><a href="{% url 'events:invite-code-entry' %}">Join Event</a></li>
                         <li><a href="{% url 'account_logout' %}">Logout</a></li>
                     {% else %}
+                        <li><a href="{% url 'events:invite-code-entry' %}">Join Event</a></li>
                         <li><a href="{% url 'account_login' %}">Login</a></li>
                         <li><a href="{% url 'account_signup' %}">Sign Up</a></li>
                     {% endif %}


### PR DESCRIPTION
## Summary

This PR adds a discoverable UI for users to join Secret Santa events via invite code. The backend join functionality was already complete, but there was no visible way for users to access it from the navigation.

### Changes Made

- **InviteCodeForm**: New form that validates 8-character event invite codes and ensures the event is active
- **InviteCodeEntryView**: Simple view that displays the form and redirects to the full join page on valid submission
- **invite_code_entry.html**: Clean, centered template with form styling matching the existing design system
- **Navigation Update**: Added "Join Event" link to both authenticated and unauthenticated navigation
- **URL Routing**: Added `/events/join/` route for the invite code entry landing page

### User Flow

1. User clicks "Join Event" in navigation (visible for all users)
2. User sees a simple form asking for invite code
3. User enters 8-character invite code
4. System validates code and redirects to `/events/join/{invite_code}/` 
5. Existing `ParticipantJoinView` handles the full registration form

### Testing

- Form validation works correctly for invalid/inactive codes
- Successful validation redirects to existing join page
- Navigation link is properly aligned with other header links
- Mobile-responsive design maintained
- Matches forest green color scheme

### Acceptance Criteria

- ✅ "Join Event" button visible in header navigation for all users
- ✅ Clicking button shows a form to enter invite code
- ✅ Valid invite code redirects to existing join page
- ✅ Invalid invite code shows appropriate error message
- ✅ UI matches existing design system
- ✅ Mobile-responsive design

Resolves #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)